### PR TITLE
依頼一覧にページネーションを付ける

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'coffee-rails', '~> 4.2'
 gem 'jbuilder', '~> 2.5'
 gem 'bootstrap_form'
 gem 'webpacker', '~> 2.0'
+gem 'kaminari'
 
 group :production do
   gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,18 @@ GEM
       multi_json (>= 1.2)
     json (2.1.0)
     jwt (1.5.6)
+    kaminari (1.0.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.0.1)
+      kaminari-activerecord (= 1.0.1)
+      kaminari-core (= 1.0.1)
+    kaminari-actionview (1.0.1)
+      actionview
+      kaminari-core (= 1.0.1)
+    kaminari-activerecord (1.0.1)
+      activerecord
+      kaminari-core (= 1.0.1)
+    kaminari-core (1.0.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -365,6 +377,7 @@ DEPENDENCIES
   factory_girl_rails
   guard-rspec
   jbuilder (~> 2.5)
+  kaminari
   listen (>= 3.0.5, < 3.2)
   mysql2
   omniauth

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -3,6 +3,9 @@ class Api::V1::MessagesController < ApplicationController
     message_params = params.permit(:page)
 
     @messages = Message.all.page(message_params[:page])
+
+    @current_page = Message.all.page(message_params[:page]).current_page
+    @has_next = Message.all.page(message_params[:page]).next_page.present?
   end
 
   def show

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -4,8 +4,8 @@ class Api::V1::MessagesController < ApplicationController
 
     @messages = Message.all.page(message_params[:page])
 
-    @current_page = Message.all.page(message_params[:page]).current_page
-    @has_next = Message.all.page(message_params[:page]).next_page.present?
+    @previous = api_v1_messages_path + '/?page=' + Message.all.page(message_params[:page]).prev_page.to_s if Message.all.page(message_params[:page]).prev_page.present?
+    @next = api_v1_messages_path + '/?page=' + Message.all.page(message_params[:page]).next_page.to_s if Message.all.page(message_params[:page]).next_page.present?
   end
 
   def show

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -1,6 +1,8 @@
 class Api::V1::MessagesController < ApplicationController
   def index
-    @messages = Message.all
+    message_params = params.permit(:page)
+
+    @messages = Message.all.page(message_params[:page])
   end
 
   def show

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -4,8 +4,8 @@ class Api::V1::MessagesController < ApplicationController
 
     @messages = Message.all.page(message_params[:page])
 
-    @previous = api_v1_messages_path + '/?page=' + Message.all.page(message_params[:page]).prev_page.to_s if Message.all.page(message_params[:page]).prev_page.present?
-    @next = api_v1_messages_path + '/?page=' + Message.all.page(message_params[:page]).next_page.to_s if Message.all.page(message_params[:page]).next_page.present?
+    @previous = api_v1_messages_path + '/?page=' + @messages.prev_page.to_s if @messages.prev_page.present?
+    @next = api_v1_messages_path + '/?page=' + @messages.next_page.to_s if @messages.next_page.present?
   end
 
   def show

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::MessagesController < ApplicationController
   def index
-    @messages = Message.all.page(params[:page])
+    @messages = Message.all.page(params[:page] || 1)
 
     @previous = api_v1_messages_path + '/?page=' + @messages.prev_page.to_s if @messages.prev_page.present?
     @next = api_v1_messages_path + '/?page=' + @messages.next_page.to_s if @messages.next_page.present?

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -1,8 +1,6 @@
 class Api::V1::MessagesController < ApplicationController
   def index
-    message_params = params.permit(:page)
-
-    @messages = Message.all.page(message_params[:page])
+    @messages = Message.all.page(params[:page])
 
     @previous = api_v1_messages_path + '/?page=' + @messages.prev_page.to_s if @messages.prev_page.present?
     @next = api_v1_messages_path + '/?page=' + @messages.next_page.to_s if @messages.next_page.present?

--- a/app/javascript/lib/api/message.js
+++ b/app/javascript/lib/api/message.js
@@ -1,8 +1,8 @@
 import axios from 'axios'
 
 export default {
-  list: () => {
-    return axios.get('/api/v1/messages');
+  list: (page) => {
+    return axios.get('/api/v1/messages', { params: { page: page } });
   },
   detail: (message_id) => {
     return axios.get('/api/v1/messages/' + message_id);

--- a/app/javascript/lib/api/message.js
+++ b/app/javascript/lib/api/message.js
@@ -1,8 +1,8 @@
 import axios from 'axios'
 
 export default {
-  list: (page) => {
-    return axios.get('/api/v1/messages', { params: { page: page } });
+  paginate: (uri = '/api/v1/messages') => {
+    return axios.get(uri);
   },
   detail: (message_id) => {
     return axios.get('/api/v1/messages/' + message_id);

--- a/app/javascript/packs/messages/index.js
+++ b/app/javascript/packs/messages/index.js
@@ -15,21 +15,31 @@ document.addEventListener('DOMContentLoaded', () => {
     data: {
       selected_message: null,
       is_loaded: false,
-      messages: []
+      messages: [],
+      paging: null
     },
     created() {
       this.fetchMessageList()
     },
     methods: {
-      fetchMessageList() {
-        Api.Message.list().then((response) => {
-          this.messages = _.map(response.data, (message) => {
+      fetchMessageList(page = null) {
+        Api.Message.list(page).then((response) => {
+          this.messages = _.map(response.data.messages, (message) => {
             message.due_at_for_view = moment(message.due_at).format('MM/DD HH:mm')
             this.is_loaded = true
             return message
           })
+          this.paging = response.data.paging
         })
       },
+      fetchNextMessages() {
+        let next_page = this.paging.current_page + 1
+        this.fetchMessageList(next_page)
+      },
+      fetchPreviousMessages() {
+        let previous_page = this.paging.current_page - 1
+        this.fetchMessageList(previous_page)
+      }
     }
   })
 })

--- a/app/javascript/packs/messages/index.js
+++ b/app/javascript/packs/messages/index.js
@@ -16,14 +16,14 @@ document.addEventListener('DOMContentLoaded', () => {
       selected_message: null,
       is_loaded: false,
       messages: [],
-      paging: null
+      paging: { previous: null, next: null }
     },
     created() {
       this.fetchMessageList()
     },
     methods: {
-      fetchMessageList(page = null) {
-        Api.Message.list(page).then((response) => {
+      fetchMessageList(uri) {
+        Api.Message.paginate(uri).then((response) => {
           this.messages = _.map(response.data.messages, (message) => {
             message.due_at_for_view = moment(message.due_at).format('MM/DD HH:mm')
             this.is_loaded = true
@@ -32,14 +32,6 @@ document.addEventListener('DOMContentLoaded', () => {
           this.paging = response.data.paging
         })
       },
-      fetchNextMessages() {
-        let next_page = this.paging.current_page + 1
-        this.fetchMessageList(next_page)
-      },
-      fetchPreviousMessages() {
-        let previous_page = this.paging.current_page - 1
-        this.fetchMessageList(previous_page)
-      }
     }
   })
 })

--- a/app/views/api/v1/messages/index.json.jbuilder
+++ b/app/views/api/v1/messages/index.json.jbuilder
@@ -16,6 +16,6 @@ json.messages do
 end
 
 json.paging do
-  json.current_page @current_page
-  json.has_next @has_next
+  json.previous @previous
+  json.next @next
 end

--- a/app/views/api/v1/messages/index.json.jbuilder
+++ b/app/views/api/v1/messages/index.json.jbuilder
@@ -1,14 +1,21 @@
-json.array! @messages do |message|
-  json.id message.id
-  json.user_id message.user_id
-  json.message message.message
-  json.due_at message.due_at
-  json.require_confirm message.require_confirm
-  json.created_at message.created_at
-  json.updated_at message.updated_at
+json.messages do
+  json.array! @messages do |message|
+    json.id message.id
+    json.user_id message.user_id
+    json.message message.message
+    json.due_at message.due_at
+    json.require_confirm message.require_confirm
+    json.created_at message.created_at
+    json.updated_at message.updated_at
 
-  json.set! :report do
-    json.answered_count message.message_answers.pluck(:mention_id).uniq.size
-    json.mentioned_count message.mentions.size
+    json.set! :report do
+      json.answered_count message.message_answers.pluck(:mention_id).uniq.size
+      json.mentioned_count message.mentions.size
+    end
   end
+end
+
+json.paging do
+  json.current_page @current_page
+  json.has_next @has_next
 end

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -25,12 +25,12 @@
 
     <nav class="pagination is-centered">
       <a class="pagination-previous"
-         v-if="this.paging.current_page > 1"
-         @click="fetchPreviousMessages()"
+         v-if="this.paging.previous"
+         @click="fetchMessageList(paging.previous)"
       >Previous</a>
       <a class="pagination-next"
-         v-if="this.paging.has_next"
-         @click="fetchNextMessages()"
+         v-if="this.paging.next"
+         @click="fetchMessageList(paging.next)"
       >Next page</a>
     </nav>
   </div>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -7,7 +7,7 @@
       </span>
       <span>Create</span>
     <% end %>
-    <table class="table" v-show="is_loaded" style="display: none;">
+    <table class="table" v-show="is_loaded" style="width: 100%; display: none;">
       <thead>
       <tr>
         <th>State</th>
@@ -25,11 +25,11 @@
 
     <nav class="pagination is-centered">
       <a class="pagination-previous"
-         v-if="this.paging.previous"
+         :disabled="!this.paging.previous"
          @click="fetchMessageList(paging.previous)"
       >Previous</a>
       <a class="pagination-next"
-         v-if="this.paging.next"
+         :disabled="!this.paging.next"
          @click="fetchMessageList(paging.next)"
       >Next page</a>
     </nav>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -23,12 +23,16 @@
       </tbody>
     </table>
 
-    <!--
     <nav class="pagination is-centered">
-      <a class="pagination-previous">Previous</a>
-      <a class="pagination-next">Next page</a>
+      <a class="pagination-previous"
+         v-if="this.paging.current_page > 1"
+         @click="fetchPreviousMessages()"
+      >Previous</a>
+      <a class="pagination-next"
+         v-if="this.paging.has_next"
+         @click="fetchNextMessages()"
+      >Next page</a>
     </nav>
-    -->
   </div>
 
   <message_detail :selected_message="selected_message"></message_detail>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.params_on_first_page = false
+end

--- a/doc/messages.md
+++ b/doc/messages.md
@@ -5,7 +5,7 @@ Response success.
 
 #### Request
 ```
-GET /api/v1/messages HTTP/1.1
+GET /api/v1/messages?page=1 HTTP/1.1
 Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
 Content-Length: 0
 Host: www.example.com
@@ -15,30 +15,348 @@ Host: www.example.com
 ```
 HTTP/1.1 200
 Cache-Control: max-age=0, private, must-revalidate
-Content-Length: 270
+Content-Length: 6900
 Content-Type: application/json; charset=utf-8
-ETag: W/"9f1a59a2b36ad1b84ee20f98e47dae95"
+ETag: W/"05d0c6d47d987f9e4d177004dc7cfa7b"
 X-Content-Type-Options: nosniff
 X-Frame-Options: SAMEORIGIN
-X-Request-Id: 2b8c929e-a099-4326-ab94-546f95ece14d
-X-Runtime: 0.070432
+X-Request-Id: 7e8d0470-b0f8-4fa5-b158-39b5eb118868
+X-Runtime: 0.078659
 X-XSS-Protection: 1; mode=block
 
-[
-  {
-    "id": 25,
-    "user_id": 25,
-    "message": "Slack User 001: Message 00001",
-    "due_at": "2017-08-12T18:47:29.000+09:00",
-    "require_confirm": true,
-    "created_at": "2017-08-29T13:30:50.000+09:00",
-    "updated_at": "2017-08-29T13:30:50.000+09:00",
-    "report": {
-      "answered_count": 0,
-      "mentioned_count": 0
+{
+  "messages": [
+    {
+      "id": 7610,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
+    },
+    {
+      "id": 7611,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
+    },
+    {
+      "id": 7612,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
+    },
+    {
+      "id": 7613,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
+    },
+    {
+      "id": 7614,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
+    },
+    {
+      "id": 7615,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
+    },
+    {
+      "id": 7616,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
+    },
+    {
+      "id": 7617,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
+    },
+    {
+      "id": 7618,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
+    },
+    {
+      "id": 7619,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
+    },
+    {
+      "id": 7620,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
+    },
+    {
+      "id": 7621,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
+    },
+    {
+      "id": 7622,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
+    },
+    {
+      "id": 7623,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
+    },
+    {
+      "id": 7624,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
+    },
+    {
+      "id": 7625,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
+    },
+    {
+      "id": 7626,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
+    },
+    {
+      "id": 7627,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
+    },
+    {
+      "id": 7628,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
+    },
+    {
+      "id": 7629,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
+    },
+    {
+      "id": 7630,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
+    },
+    {
+      "id": 7631,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
+    },
+    {
+      "id": 7632,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
+    },
+    {
+      "id": 7633,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
+    },
+    {
+      "id": 7634,
+      "user_id": 2417,
+      "message": "Slack User 001: Message 00001",
+      "due_at": "2017-08-12T18:47:29.000+09:00",
+      "require_confirm": true,
+      "created_at": "2017-09-08T00:24:00.000+09:00",
+      "updated_at": "2017-09-08T00:24:00.000+09:00",
+      "report": {
+        "answered_count": 0,
+        "mentioned_count": 0
+      }
     }
+  ],
+  "paging": {
+    "previous": null,
+    "next": "/api/v1/messages/?page=2"
   }
-]
+}
 ```
 
 ## GET /api/v1/messages/:message_id
@@ -48,7 +366,7 @@ Response success.
 
 #### Request
 ```
-GET /api/v1/messages/26 HTTP/1.1
+GET /api/v1/messages/7662 HTTP/1.1
 Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
 Content-Length: 0
 Host: www.example.com
@@ -58,27 +376,27 @@ Host: www.example.com
 ```
 HTTP/1.1 200
 Cache-Control: max-age=0, private, must-revalidate
-Content-Length: 441
+Content-Length: 447
 Content-Type: application/json; charset=utf-8
-ETag: W/"46c382972de86466eb3b9bdf092d13ac"
+ETag: W/"3153828d58321d3e137b0e0c04dcb9d9"
 X-Content-Type-Options: nosniff
 X-Frame-Options: SAMEORIGIN
-X-Request-Id: e105611d-34d3-42c0-8112-b1813a643d8c
-X-Runtime: 0.035190
+X-Request-Id: 75da6cb0-5fbc-40ec-b749-316bf2937350
+X-Runtime: 0.025317
 X-XSS-Protection: 1; mode=block
 
 {
-  "id": 26,
-  "user_id": 26,
+  "id": 7662,
+  "user_id": 2419,
   "message": "Slack User 001: Message 00001",
   "due_at": "2017-08-12T18:47:29.000+09:00",
   "require_confirm": true,
-  "created_at": "2017-08-29T13:30:50.000+09:00",
-  "updated_at": "2017-08-29T13:30:50.000+09:00",
+  "created_at": "2017-09-08T00:24:00.000+09:00",
+  "updated_at": "2017-09-08T00:24:00.000+09:00",
   "report": {
     "answers": [
       {
-        "text": "text",
+        "text": "text1",
         "count": 1,
         "percentage": 100.0
       }
@@ -89,8 +407,8 @@ X-XSS-Protection: 1; mode=block
         "profile_picture_url": "http://hoge/user0.jpg",
         "answers": [
           {
-            "answer": "text",
-            "answered_date": "2017-08-29T13:30:50.000+09:00"
+            "answer": "text1",
+            "answered_date": "2017-09-08T00:24:00.000+09:00"
           }
         ]
       }
@@ -119,46 +437,47 @@ message=hoge&require_confirm=0&due_at=2017-08-15+10%3A00%3A00&button_type=single
 ```
 HTTP/1.1 201
 Cache-Control: max-age=0, private, must-revalidate
-Content-Length: 517
+Content-Length: 695
 Content-Type: application/json; charset=utf-8
-ETag: W/"0a12d63e465153086f7adce48fd4cc44"
+ETag: W/"320561fae1b6efcc67acdb9db396780d"
 X-Content-Type-Options: nosniff
 X-Frame-Options: SAMEORIGIN
-X-Request-Id: c63762bf-40d6-42ba-969b-6146fd7fccd3
-X-Runtime: 0.025759
+X-Request-Id: e37adb8e-c0de-4b04-8464-08fd2ab27d4e
+X-Runtime: 0.028071
 X-XSS-Protection: 1; mode=block
 
 {
-  "id": null,
-  "user_id": 1,
+  "id": 7663,
+  "user_id": 2420,
   "message": "hoge",
   "due_at": "2017-08-15T10:00:00.000+09:00",
   "require_confirm": false,
-  "created_at": null,
-  "updated_at": null,
-  "callback_id": "c86613e2111d09a1",
+  "created_at": "2017-09-08T00:24:01.000+09:00",
+  "updated_at": "2017-09-08T00:24:01.000+09:00",
+  "callback_id": "2b63ec2bd93a58c3",
   "button_type": "single",
   "message_buttons": [
     {
-      "id": null,
-      "message_id": null,
-      "name": "3e31c8f6c339b393",
+      "id": 968,
+      "message_id": 7663,
+      "name": "7b0c5208356c0e22",
       "text": "button01",
-      "created_at": null,
-      "updated_at": null
+      "created_at": "2017-09-08T00:24:01.000+09:00",
+      "updated_at": "2017-09-08T00:24:01.000+09:00"
     }
   ],
   "mentions": [
     {
-      "id": null,
-      "message_id": null,
+      "id": 1079,
+      "message_id": 7663,
       "slack_id": "UHOGEHOGE",
-      "created_at": null,
-      "updated_at": null,
+      "created_at": "2017-09-08T00:24:01.000+09:00",
+      "updated_at": "2017-09-08T00:24:01.000+09:00",
       "name": "fuga",
       "profile_picture_url": "http://hoge.com/fuga.jpg",
       "channel": null,
-      "ts": null
+      "ts": null,
+      "text": "hoge"
     }
   ]
 }

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe "Messages", type: :request do
         expect(response).to be_success
         expect(response.status).to eq 200
         expect(json_parse['messages'].count).to eq 1
-        expect(json_parse['paging']['current_page']).to eq 1
-        expect(json_parse['paging']['has_next']).to eq false
+        expect(json_parse['paging']['previous']).to eq nil
+        expect(json_parse['paging']['next']).to eq nil
         expect(parse_response['user_id']).to eq user.id
         expect(parse_response['message']).to eq message.message
         expect(parse_response['due_at']).to eq message.due_at.as_json
@@ -33,8 +33,8 @@ RSpec.describe "Messages", type: :request do
         expect(response).to be_success
         expect(response.status).to eq 200
         expect(json_parse['messages'].count).to eq 25
-        expect(json_parse['paging']['current_page']).to eq 1
-        expect(json_parse['paging']['has_next']).to eq true
+        expect(json_parse['paging']['previous']).to eq nil
+        expect(json_parse['paging']['next']).to eq '/api/v1/messages/?page=2'
       end
     end
 
@@ -48,8 +48,8 @@ RSpec.describe "Messages", type: :request do
         expect(response).to be_success
         expect(response.status).to eq 200
         expect(json_parse['messages'].count).to eq 25
-        expect(json_parse['paging']['current_page']).to eq 1
-        expect(json_parse['paging']['has_next']).to eq true
+        expect(json_parse['paging']['previous']).to eq nil
+        expect(json_parse['paging']['next']).to eq '/api/v1/messages/?page=2'
       end
     end
 
@@ -64,8 +64,8 @@ RSpec.describe "Messages", type: :request do
         expect(response).to be_success
         expect(response.status).to eq 200
         expect(json_parse['messages'].count).to eq 1
-        expect(json_parse['paging']['current_page']).to eq 2
-        expect(json_parse['paging']['has_next']).to eq false
+        expect(json_parse['paging']['previous']).to eq '/api/v1/messages/?page=1'
+        expect(json_parse['paging']['next']).to eq nil
       end
     end
   end

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -6,14 +6,16 @@ RSpec.describe "Messages", type: :request do
 
     context 'when has no pagination parameter' do
       let!(:message) { create(:message, user: user) }
-      let(:parse_response) { json_parse.first }
+      let(:parse_response) { json_parse['messages'].first }
 
       before { get api_v1_messages_path }
 
       it 'response success', autodoc: true do
         expect(response).to be_success
         expect(response.status).to eq 200
-        expect(json_parse.count).to eq 1
+        expect(json_parse['messages'].count).to eq 1
+        expect(json_parse['paging']['current_page']).to eq 1
+        expect(json_parse['paging']['has_next']).to eq false
         expect(parse_response['user_id']).to eq user.id
         expect(parse_response['message']).to eq message.message
         expect(parse_response['due_at']).to eq message.due_at.as_json
@@ -30,7 +32,9 @@ RSpec.describe "Messages", type: :request do
       it 'response success' do
         expect(response).to be_success
         expect(response.status).to eq 200
-        expect(json_parse.count).to eq 25
+        expect(json_parse['messages'].count).to eq 25
+        expect(json_parse['paging']['current_page']).to eq 1
+        expect(json_parse['paging']['has_next']).to eq true
       end
     end
 
@@ -43,7 +47,9 @@ RSpec.describe "Messages", type: :request do
       it 'response success' do
         expect(response).to be_success
         expect(response.status).to eq 200
-        expect(json_parse.count).to eq 25
+        expect(json_parse['messages'].count).to eq 25
+        expect(json_parse['paging']['current_page']).to eq 1
+        expect(json_parse['paging']['has_next']).to eq true
       end
     end
 
@@ -57,7 +63,9 @@ RSpec.describe "Messages", type: :request do
       it 'response success' do
         expect(response).to be_success
         expect(response.status).to eq 200
-        expect(json_parse.count).to eq 1
+        expect(json_parse['messages'].count).to eq 1
+        expect(json_parse['paging']['current_page']).to eq 2
+        expect(json_parse['paging']['has_next']).to eq false
       end
     end
   end

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Messages", type: :request do
 
       before { get api_v1_messages_path }
 
-      it 'response success', autodoc: true do
+      it 'response success' do
         expect(response).to be_success
         expect(response.status).to eq 200
         expect(json_parse['messages'].count).to eq 1
@@ -38,7 +38,7 @@ RSpec.describe "Messages", type: :request do
       end
     end
 
-    context 'when has 26 messages and fetch page 1' do
+    context 'when has 26 messages and fetch page 1', autodoc: true do
       before do
         26.times { create(:message, user: user) }
         get api_v1_messages_path, params: { page: 1 }

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe "Messages", type: :request do
     let!(:message) { create(:message, user: user) }
     let(:parse_response) { json_parse.first }
 
-    before do
-      get api_v1_messages_path
-    end
+    before { get api_v1_messages_path }
 
     it 'response success', autodoc: true do
       expect(response).to be_success

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -3,19 +3,62 @@ require 'rails_helper'
 RSpec.describe "Messages", type: :request do
   describe "GET /api/v1/messages" do
     let!(:user) { create(:user) }
-    let!(:message) { create(:message, user: user) }
-    let(:parse_response) { json_parse.first }
 
-    before { get api_v1_messages_path }
+    context 'when has no pagination parameter' do
+      let!(:message) { create(:message, user: user) }
+      let(:parse_response) { json_parse.first }
 
-    it 'response success', autodoc: true do
-      expect(response).to be_success
-      expect(response.status).to eq 200
-      expect(json_parse.count).to eq 1
-      expect(parse_response['user_id']).to eq user.id
-      expect(parse_response['message']).to eq message.message
-      expect(parse_response['due_at']).to eq message.due_at.as_json
-      expect(parse_response['require_confirm']).to eq message.require_confirm
+      before { get api_v1_messages_path }
+
+      it 'response success', autodoc: true do
+        expect(response).to be_success
+        expect(response.status).to eq 200
+        expect(json_parse.count).to eq 1
+        expect(parse_response['user_id']).to eq user.id
+        expect(parse_response['message']).to eq message.message
+        expect(parse_response['due_at']).to eq message.due_at.as_json
+        expect(parse_response['require_confirm']).to eq message.require_confirm
+      end
+    end
+
+    context 'when has 26 messages and no page parameter' do
+      before do
+        26.times { create(:message, user: user) }
+        get api_v1_messages_path
+      end
+
+      it 'response success' do
+        expect(response).to be_success
+        expect(response.status).to eq 200
+        expect(json_parse.count).to eq 25
+      end
+    end
+
+    context 'when has 26 messages and fetch page 1' do
+      before do
+        26.times { create(:message, user: user) }
+        get api_v1_messages_path, params: { page: 1 }
+      end
+
+      it 'response success' do
+        expect(response).to be_success
+        expect(response.status).to eq 200
+        expect(json_parse.count).to eq 25
+      end
+    end
+
+
+    context 'when has 26 messages and fetch page 2' do
+      before do
+        26.times { create(:message, user: user) }
+        get api_v1_messages_path, params: { page: 2 }
+      end
+
+      it 'response success' do
+        expect(response).to be_success
+        expect(response.status).to eq 200
+        expect(json_parse.count).to eq 1
+      end
     end
   end
 


### PR DESCRIPTION
## このPRですること
件名の通り、Next/Previousのページネーションを付ける。

![pagination2](https://user-images.githubusercontent.com/1726225/30172176-05a44e9c-942f-11e7-8f46-f102c3cc84da.gif)

※ １ページ２件で動作させているデモです。

### 参考
* [kaminari/kaminari: ⚡ A Scope & Engine based, clean, powerful, customizable and sophisticated paginator for Ruby webapps](https://github.com/kaminari/kaminari)