### PR TITLE
Rails5-ize README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,10 @@ $ yarn install
 $ brew services start redis
 ```
 
-* Database creation
+* Setup database
 
 ```bash
-$ bin/rake db:create
-```
-
-* Database initialization
-
-```bash
-$ bin/rake db:migrate
+$ bin/rails db:setup
 ```
 
 * API Document


### PR DESCRIPTION
In Rails 5.0, all rake tasks were replaced with rails command.

- http://guides.rubyonrails.org/5_0_release_notes.html

And It looks not reasonable to write 2 database setup commands (`db:create`, `db:migrate`) separately.
So I try to fix it with a command `db:setup`.
Do you think about it ?