### PR TITLE
回答結果のパーセント表記で小数点以下を表示しない

### DIFF
--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::MessagesController < ApplicationController
       {
         text: b.text,
         count: b.message_answers.size,
-        percentage: (b.message_answers.size.to_f / @message.message_answers.size) * 100
+        percentage: Message.calc_percentage(@message.message_answers.size, b.message_answers.size)
       }
     end
   end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -5,4 +5,8 @@ class Message < ApplicationRecord
   has_many :message_answers
 
   enum button_type: %w(single multi)
+
+  def self.calc_percentage(num, total)
+    ( num / total.to_f) * 100
+  end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -7,6 +7,7 @@ class Message < ApplicationRecord
   enum button_type: %w(single multi)
 
   def self.calc_percentage(num, total)
-    ( num / total.to_f) * 100
+    # No decimal point required. ex) 36.36363636363637 to 36
+    ((num / total.to_f) * 100).round
   end
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe Message, type: :model do
+  describe '#calc_percentage' do
+    context 'Divisible' do
+      before { @result = Message.calc_percentage(1, 2) }
+      it { expect(@result).to eq 50 }
+    end
+
+    context 'Not divisible' do
+      before { @result = Message.calc_percentage(4, 11) }
+      it { expect(@result).to eq 36.36363636363637 }
+    end
+  end
+end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -9,7 +9,7 @@ describe Message, type: :model do
 
     context 'Not divisible' do
       before { @result = Message.calc_percentage(4, 11) }
-      it { expect(@result).to eq 36.36363636363637 }
+      it { expect(@result).to eq 36 }
     end
   end
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 describe Message, type: :model do
   describe '#calc_percentage' do
-    context 'Divisible' do
+    context 'When giving divisible values' do
       before { @result = Message.calc_percentage(1, 2) }
       it { expect(@result).to eq 50 }
     end
 
-    context 'Not divisible' do
+    context 'When giving no divisible values' do
       before { @result = Message.calc_percentage(4, 11) }
       it { expect(@result).to eq 36 }
     end

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -90,9 +90,7 @@ RSpec.describe "Messages", type: :request do
     let!(:answer) { create(:message_answer, message: message, message_button: button, mention: mention) }
     let(:parse_response) { json_parse }
 
-    before do
-      get api_v1_message_path message.id
-    end
+    before { get api_v1_message_path message.id }
 
     it 'response success', autodoc: true do
       expect(response).to be_success


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1726225/30388953-5e41072c-98ec-11e7-801e-585d7d84cec0.png)

となってしまい見窄らしいので、小数点以下を四捨五入し小数点以下の表示を無くします。