### PR TITLE
回答のパーセント計算の値を誤って逆に渡してしまった

### DIFF
--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::MessagesController < ApplicationController
       {
         text: b.text,
         count: b.message_answers.size,
-        percentage: Message.calc_percentage(@message.message_answers.size, b.message_answers.size)
+        percentage: Message.calc_percentage(b.message_answers.size, @message.message_answers.size)
       }
     end
   end


### PR DESCRIPTION
誤ってコントローラー側の値を逆にしてしまい、パーセント計算を狂わせてしまったので、値の受け渡しを元に戻します。 🙇 

![image](https://user-images.githubusercontent.com/1726225/30389833-fa7075e0-98ee-11e7-8dc4-80a39ca17a62.png)
