### PR TITLE
回答が0件の場合に詳細画面が開けないバグを修正する

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -7,6 +7,8 @@ class Message < ApplicationRecord
   enum button_type: %w(single multi)
 
   def self.calc_percentage(num, total)
+    return 0 if total == 0
+
     # No decimal point required. ex) 36.36363636363637 to 36
     ((num / total.to_f) * 100).round
   end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -2,6 +2,11 @@ require 'rails_helper'
 
 describe Message, type: :model do
   describe '#calc_percentage' do
+    context 'When giving 0' do
+      before { @result = Message.calc_percentage(0, 0) }
+      it { expect(@result).to eq 0 }
+    end
+
     context 'When giving divisible values' do
       before { @result = Message.calc_percentage(1, 2) }
       it { expect(@result).to eq 50 }

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -102,8 +102,8 @@ RSpec.describe "Messages", type: :request do
         expect(parse_response['require_confirm']).to eq message.require_confirm
 
         expect(parse_response['report']['answers'].first['text']).to eq button.text
-        expect(parse_response['report']['answers'].first['count']).to eq 1
-        expect(parse_response['report']['answers'].first['percentage']).to eq 100
+        expect(parse_response['report']['answers'].first['count']).to eq 0
+        expect(parse_response['report']['answers'].first['percentage']).to eq 0
 
         expect(parse_response['report']['mentioned'].first['name']).to eq mention.name
         expect(parse_response['report']['mentioned'].first['profile_picture_url']).to eq mention.profile_picture_url

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -87,26 +87,50 @@ RSpec.describe "Messages", type: :request do
     let!(:message) { create(:message, user: user) }
     let!(:button) { create(:message_button, message: message) }
     let!(:mention) { create(:mention, message: message) }
-    let!(:answer) { create(:message_answer, message: message, message_button: button, mention: mention) }
     let(:parse_response) { json_parse }
 
-    before { get api_v1_message_path message.id }
+    context 'when has message with no answer.' do
+      before { get api_v1_message_path message.id }
 
-    it 'response success', autodoc: true do
-      expect(response).to be_success
-      expect(response.status).to eq 200
+      it 'response success' do
+        expect(response).to be_success
+        expect(response.status).to eq 200
 
-      expect(parse_response['user_id']).to eq user.id
-      expect(parse_response['message']).to eq message.message
-      expect(parse_response['due_at']).to eq message.due_at.as_json
-      expect(parse_response['require_confirm']).to eq message.require_confirm
+        expect(parse_response['user_id']).to eq user.id
+        expect(parse_response['message']).to eq message.message
+        expect(parse_response['due_at']).to eq message.due_at.as_json
+        expect(parse_response['require_confirm']).to eq message.require_confirm
 
-      expect(parse_response['report']['answers'].first['text']).to eq button.text
-      expect(parse_response['report']['answers'].first['count']).to eq 1
-      expect(parse_response['report']['answers'].first['percentage']).to eq 100
+        expect(parse_response['report']['answers'].first['text']).to eq button.text
+        expect(parse_response['report']['answers'].first['count']).to eq 1
+        expect(parse_response['report']['answers'].first['percentage']).to eq 100
 
-      expect(parse_response['report']['mentioned'].first['name']).to eq mention.name
-      expect(parse_response['report']['mentioned'].first['profile_picture_url']).to eq mention.profile_picture_url
+        expect(parse_response['report']['mentioned'].first['name']).to eq mention.name
+        expect(parse_response['report']['mentioned'].first['profile_picture_url']).to eq mention.profile_picture_url
+      end
+    end
+
+    context 'when has message with 1 answer.' do
+      let!(:answer) { create(:message_answer, message: message, message_button: button, mention: mention) }
+
+      before { get api_v1_message_path message.id }
+
+      it 'response success', autodoc: true do
+        expect(response).to be_success
+        expect(response.status).to eq 200
+
+        expect(parse_response['user_id']).to eq user.id
+        expect(parse_response['message']).to eq message.message
+        expect(parse_response['due_at']).to eq message.due_at.as_json
+        expect(parse_response['require_confirm']).to eq message.require_confirm
+
+        expect(parse_response['report']['answers'].first['text']).to eq button.text
+        expect(parse_response['report']['answers'].first['count']).to eq 1
+        expect(parse_response['report']['answers'].first['percentage']).to eq 100
+
+        expect(parse_response['report']['mentioned'].first['name']).to eq mention.name
+        expect(parse_response['report']['mentioned'].first['profile_picture_url']).to eq mention.profile_picture_url
+      end
     end
   end
 


### PR DESCRIPTION
ref: https://github.com/pepabo/collec/issues/91

### 発生していたバグ
回答が0件の場合に以下のようになってしまう。

![image](https://user-images.githubusercontent.com/1726225/30589036-f3c921b8-9d73-11e7-9258-ae3417f7ed07.png)

### 原因
https://github.com/pepabo/collec/pull/87 を実装した時にゼロ除算が起きてしまい、それが原因でAPIがエラーとなってしまいました。
